### PR TITLE
[GRDM-35917] GakuNin RDM機関ストレージ対応

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdmaddins
 Title: RDM BinderHub Addins for RStudio
-Version: 0.1
+Version: 0.2
 Description: Sync to RDM menu
 Depends: R (>= 3.0.0)
 Imports:

--- a/R/syncToRDM.R
+++ b/R/syncToRDM.R
@@ -6,8 +6,10 @@ syncToRDM <- function() {
   jh_env = fromJSON('~/.config/grdm/env.json')
   jh_user = jh_env['JUPYTERHUB_USER']
   jh_server_name = jh_env['JUPYTERHUB_SERVER_NAME']
+  binder_repo_url = jh_env['BINDER_REPO_URL']
   yyyymmdd = format(Sys.time(), '%Y%m%d')
-  to_path = sprintf('/mnt/rdm/osfstorage/result-%s-%s-%s/', jh_user, yyyymmdd, jh_server_name)
+  storage_provider = strsplit(binder_repo_url, "/")[[1]][5]
+  to_path = sprintf('/mnt/rdm/%s/result-%s-%s-%s/', stoarge_provider, jh_user, yyyymmdd, jh_server_name)
   cat(sprintf('Syncing...: ~/result -> %s\n', to_path))
   if (!dir.exists(to_path)) {
     dir.create(to_path)


### PR DESCRIPTION
GakuNin RDM機関ストレージ対応のため、結果の保存先を /mnt/rdm/(起動元ストレージ) とするように修正を行いました。

Related to: https://github.com/RCOSDP/CS-jupyterlab-grdm/pull/3